### PR TITLE
Save input text on blur

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -164,6 +164,7 @@ const Editable: React.FC<EditableProps> = ({
               onKeyDown={handleKeyDown}
               minLength={inputMinLength}
               maxLength={inputMaxLength}
+              onBlur={handleSaveText}
               />
             {
               (inputPattern && popupVisibile) ? 


### PR DESCRIPTION
When a user clicks away from the input field, attempt to save the text 